### PR TITLE
deliver youtube embed without protocol

### DIFF
--- a/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
+++ b/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
@@ -63,7 +63,7 @@
 				break;
 				
 				case YOUTUBE:
-					return "http://www.youtube.com/embed/$vid?controls=2";
+					return "//www.youtube.com/embed/$vid?controls=2";
 				break;
 				
 				default:


### PR DESCRIPTION
Hi there. We had an issue with a youtube video embed because our site runs with https. This modification seemed to resolve the issue.