### PR TITLE
Support video embed options as argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ craft-video-embed-utility
 A Craft CMS plugin providing a Twig filter for embedding video from YouTube and Vimeo URLs
 
 ## Usage:
+
 Once installed, a videoEmbed filter will be available to your templates allowing you to embed a video in your page with just the url:
 
     {{https://www.youtube.com/watch?v=6-HUgzYPm9g|videoEmbed}}
 
+The filter also allows you to provide embed options ([Vimeo example](https://developer.vimeo.com/player/embedding)) as the first argument in the filter:
+
+    {{url|videoEmbed({ byline: 0, autoplay: 1 })}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Once installed, a videoEmbed filter will be available to your templates allowing
 
     {{https://www.youtube.com/watch?v=6-HUgzYPm9g|videoEmbed}}
 
-The filter also allows you to provide embed options ([Vimeo example](https://developer.vimeo.com/player/embedding)) as the first argument in the filter:
+The filter also allows you to provide querystring based embed options as the first argument in the filter:
 
     {{url|videoEmbed({ byline: 0, autoplay: 1 })}
+
+* [Vimeo embed options](https://developer.vimeo.com/player/embedding).
+* [YouTube embed options](https://developers.google.com/youtube/player_parameters).

--- a/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
+++ b/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
@@ -40,7 +40,7 @@
 			$host = $this->videoHost($videoUrl);
 			switch($host) {
 				case VIMEO:
-					if(preg_match('/\/([0-9]+)\/*$/',$videoUrl,$matches) !== false) {
+					if(preg_match('/\/([0-9]+)\/*(\?.*)?$/',$videoUrl,$matches) !== false) {
 						return $matches[1];
 					}
 				break;
@@ -48,7 +48,7 @@
 				case YOUTUBE:
 					if(preg_match('/[&,v]=([^&]+)/',$videoUrl,$matches) !== false)
 						return $matches[1];
-				break;			
+				break;
 			}
 			return "";
 		}
@@ -62,7 +62,7 @@
 				
 				case YOUTUBE:
 					return "//www.youtube.com/embed/$vid?controls=2";
-				break;				
+				break;
 			}
 			return "";
 		}
@@ -77,18 +77,22 @@
 			return $needle === "" || substr($haystack, -strlen($needle)) === $needle;
 		}
 		
-		public function videoEmbed($input) {
-		    $url = $this->videoPlayerUrl($input);
-		    if(!empty($url)) {
-    			$originalPath = craft()->path->getTemplatesPath();
-    			$myPath = craft()->path->getPluginsPath() . 'videoembedutility/templates/';
-    			craft()->path->setTemplatesPath($myPath);
-    			$markup = craft()->templates->render('_vimeoEmbed.html', array(
-    				'player_url' => $url
-    			));
-    			craft()->path->setTemplatesPath($originalPath);
-    			return TemplateHelper::getRaw($markup);
-    		}
+		public function videoEmbed($input, $options = array()) {
+			$url = $this->videoPlayerUrl($input);
+			if(!empty($url)) {
+				if(!empty($options)) {
+					$url .= '?' . http_build_query($options);
+				}
+				
+				$originalPath = craft()->path->getTemplatesPath();
+				$myPath = craft()->path->getPluginsPath() . 'videoembedutility/templates/';
+				craft()->path->setTemplatesPath($myPath);
+				$markup = craft()->templates->render('_vimeoEmbed.html', array(
+					'player_url' => $url
+				));
+				craft()->path->setTemplatesPath($originalPath);
+				return TemplateHelper::getRaw($markup);
+			}
 		}
 		
 		public function getName() {


### PR DESCRIPTION
Allows you to provide video embed options when using the `videoEmbed` filter. Adding them onto the URL was breaking the Vimeo embed functionality because of the pattern not allowing trailing characters other than the video ID, so I fixed that and thought the options being an argument would be nicer / easier to read.