### PR TITLE
Updated README to include Facebook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 craft-video-embed-utility
 =========================
 
-A Craft CMS plugin providing a Twig filter for embedding video from YouTube and Vimeo URLs
+A Craft CMS plugin providing a Twig filter for converting YouTube, Vimeo and Facebook URLs into an embedded video <iframe> with the necessary settings applied.
 
 ## Usage:
 
-Once installed, a videoEmbed filter will be available to your templates allowing you to embed a video in your page with just the url:
+Once installed, a `videoEmbed` filter will be available to your templates allowing you to embed a video in your page with just the URL:
 
     {{https://www.youtube.com/watch?v=6-HUgzYPm9g|videoEmbed}}
 


### PR DESCRIPTION
Slight tweaks to the README to explain Facebook support, which separates this plugin from https://github.com/vigetlabs/craft-videoembed