### PR TITLE
Remove default controls=2 for youtube embeds

### DIFF
--- a/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
+++ b/videoembedutility/twigextensions/VideoEmbedUtilityTwigExtension.php
@@ -65,7 +65,7 @@
 				
 				case YOUTUBE:
 				case YOUTUBE_SHORT:
-					return "//www.youtube.com/embed/$videoId?controls=2";
+					return "//www.youtube.com/embed/$videoId?";
 				break;
 
 				case FACEBOOK:


### PR DESCRIPTION
There is currently an issue with the youtube preview image when controls=2 is set.

https://productforums.google.com/forum/#!topic/youtube/hq8sHME_6yQ;context-place=topicsearchin/youtube/category$3Areport-a-technical-issue%7Csort:relevance%7Cspell:false

This way controls=2 is not set by default, but could still be set using videoEmbed({controls: 2})

Should also solve #15 